### PR TITLE
Feat/add to favorites

### DIFF
--- a/api-gateway/src/config/authRoutes.config.ts
+++ b/api-gateway/src/config/authRoutes.config.ts
@@ -39,9 +39,16 @@ export const authRoutesConfig = {
       path: "/api/v1/wallet/stripe/create-checkout-session",
       methods: ["POST", "GET", "PATCH"],
     },
-
     { path: "/api/v1/wallet/get-transactions", methods: ["GET"] },
     { path: "/api/v1/wallet/create-transactions", methods: ["POST"] },
+
+    { path: "/api/v1/art/like", methods: ["POST"] },
+    { path: "/api/v1/art/unlike", methods: ["DELETE"] },
+    { path: "/api/v1/art/likes/:postId", methods: ["GET"] },
+
+    { path: "/api/v1/art/favorite", methods: ["POST"] },
+    { path: "/api/v1/art/unfavorite", methods: ["DELETE"] },
+    { path: "/api/v1/art/favorites/:postId", methods: ["GET"] },
   ],
 
   user_optional: [

--- a/frontend/src/features/user/components/art/ArtCard.tsx
+++ b/frontend/src/features/user/components/art/ArtCard.tsx
@@ -7,6 +7,9 @@ import { useUnlikePost } from "../../hooks/art/useUnlikePost";
 import { useSelector } from "react-redux";
 import type { RootState } from "../../../../redux/store";
 import { ArtCardLikeButton } from "./ArtCardLikeButton";
+import { useFavoritePost } from "../../hooks/art/useFavoritePost";
+import { useUnfavoritePost } from "../../hooks/art/useUnfavoritePost";
+import { ArtCardFavoriteButton } from "./ArtCardFavoriteButton";
 
 interface ArtCardProps {
   item: ArtWithUser;
@@ -20,6 +23,8 @@ const ArtCard: React.FC<ArtCardProps> = ({ item, lastArtRef }) => {
 
   const likePost = useLikePost();
   const unlikePost = useUnlikePost();
+   const favoritePost = useFavoritePost();
+  const unfavoritePost = useUnfavoritePost();
 
   const handleArtClick = () => {
     navigate(`/${item?.user?.username}/art/${item.art.artName}`);
@@ -47,6 +52,19 @@ const ArtCard: React.FC<ArtCardProps> = ({ item, lastArtRef }) => {
         postId: item.art.id, 
         artname: item.art.artName 
       });
+    }
+  };
+
+   const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!user.user || !user.isAuthenticated) {
+      navigate("/login");
+      return;
+    }
+    if (item.isFavorited) {
+      unfavoritePost.mutate({ postId: item.art.id, artname: item.art.artName });
+    } else {
+      favoritePost.mutate({ postId: item.art.id, artname: item.art.artName });
     }
   };
 
@@ -116,12 +134,12 @@ const ArtCard: React.FC<ArtCardProps> = ({ item, lastArtRef }) => {
               <MessageSquare size={20} />
               <span className="text-sm min-w-[20px] text-right">{item.commentCount}</span>
             </button>
-            <button
-              onClick={(e) => e.stopPropagation()}
-              className="bg-white/10 p-2 rounded-full hover:bg-black/70 text-white"
-            >
-              <Star size={20} />
-            </button>
+             <ArtCardFavoriteButton
+              isFavorited={item.isFavorited}
+              favoriteCount={item.favoriteCount}
+              onClick={handleFavoriteClick}
+              size={20}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/features/user/components/art/ArtCardFavoriteButton.tsx
+++ b/frontend/src/features/user/components/art/ArtCardFavoriteButton.tsx
@@ -1,0 +1,40 @@
+import { Star } from "lucide-react";
+import { useState } from "react";
+
+interface ArtCardFavoriteButtonProps {
+  isFavorited: boolean;
+  favoriteCount: number;
+  onClick: (e: React.MouseEvent) => void;
+  size?: number;
+}
+
+export const ArtCardFavoriteButton: React.FC<ArtCardFavoriteButtonProps> = ({
+  isFavorited,
+  favoriteCount,
+  onClick,
+  size = 20,
+}) => {
+  const [animate, setAnimate] = useState(false);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setAnimate(true);
+    onClick(e);
+    setTimeout(() => setAnimate(false), 300);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="flex items-center gap-1 bg-white/10 p-2 rounded-full hover:bg-black/70 text-white transition-all duration-200"
+    >
+      <Star
+        size={size}
+        className={`transition-transform duration-300 ${
+          isFavorited ? "text-yellow-400 fill-yellow-400" : "text-white"
+        } ${animate ? "scale-125" : "scale-100"}`}
+      />
+      <span className="text-sm min-w-[20px] text-right">{favoriteCount}</span>
+    </button>
+  );
+};

--- a/frontend/src/features/user/components/art/FavoriteUsersModal.tsx
+++ b/frontend/src/features/user/components/art/FavoriteUsersModal.tsx
@@ -1,0 +1,237 @@
+import React, { useState } from "react";
+import { X, ArrowDownRight } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { useNavigate } from "react-router-dom";
+import {
+  useGetFavoritedUsers,
+  type FavoritedUser,
+} from "../../hooks/art/useGetFavoritedUsers";
+import UserListSkeleton from "../skeletons/UserListSkeleton";
+import { Button } from "../../../../components/ui/button";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../../../redux/store";
+import { useGetSupporting } from "../../hooks/profile/useGetSupporting";
+import { useSupportMutation } from "../../hooks/profile/useSupportMutation";
+import { useUnSupportMutation } from "../../hooks/profile/useUnSupportMutation";
+import CustomLoader from "../../../../components/CustomLoader";
+import { formatNumber } from "../../../../libs/formatNumber";
+
+interface FavoriteUsersModalProps {
+  postId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const FavoriteUsersModal: React.FC<FavoriteUsersModalProps> = ({
+  postId,
+  isOpen,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  const user = useSelector((state: RootState) => state.user.user);
+  const currentUserId = user?.id;
+
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+    isRefetching,
+  } = useGetFavoritedUsers(postId, isOpen);
+
+  // Get current user's supporting list
+  const currentUserSupportingQuery = useGetSupporting(currentUserId || "");
+  const currentUserSupportingIds =
+    currentUserSupportingQuery.data?.pages.flatMap((p) =>
+      p.data.map((u) => u.id)
+    ) || [];
+
+  // Mutations
+  const supportMutation = useSupportMutation();
+  const unSupportMutation = useUnSupportMutation();
+  const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const allUsers = data?.pages.flatMap((page) => page.users) || [];
+
+  const handleSupportClick = (
+    e: React.MouseEvent,
+    targetUser: { id: string; username: string },
+    isSupporting: boolean
+  ) => {
+    e.stopPropagation();
+    if (loadingUserId) return;
+    setLoadingUserId(targetUser.id);
+
+    const payload = { userId: targetUser.id, username: targetUser.username };
+
+    if (isSupporting) {
+      unSupportMutation.mutate(payload, {
+        onSuccess: () => {
+          setLoadingUserId(null);
+          currentUserSupportingQuery.refetch();
+        },
+        onError: () => setLoadingUserId(null),
+      });
+    } else {
+      supportMutation.mutate(payload, {
+        onSuccess: () => {
+          setLoadingUserId(null);
+          currentUserSupportingQuery.refetch();
+        },
+        onError: () => setLoadingUserId(null),
+      });
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* modal */}
+      <div className="relative z-50 bg-white dark:bg-secondary-color border sm:dark:border-zinc-700 sm:rounded-3xl shadow-lg h-full sm:h-[500px] w-full sm:w-[470px] p-4 flex flex-col">
+        {/* close button */}
+        <button
+          className="absolute top-3 right-3 text-zinc-500 hover:text-zinc-700 dark:hover:text-white"
+          onClick={onClose}
+        >
+          <X size={20} />
+        </button>
+
+        {/* title + refetch button */}
+        <div className="flex justify-between items-center mb-4 pb-2 border-b border-zinc-300 dark:border-zinc-700">
+          <h2 className="text-lg text-center font-bold">Favorites ( {formatNumber(data?.pages?.[0]?.favoriteCount ?? 0)} )</h2>
+          <button
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="text-sm text-blue-500 pr-10 hover:text-blue-700 disabled:opacity-50"
+          >
+            {isRefetching ? "Refreshing..." : "Refetch"}
+          </button>
+        </div>
+
+        {/* user list */}
+        <ul className="flex-1 overflow-y-auto space-y-3 mt-2">
+          {isLoading &&
+            [...Array(5)].map((_, i) => <UserListSkeleton key={i} />)}
+          {isError && (
+            <p className="text-center text-red-500">Error fetching users.</p>
+          )}
+          {!isLoading && allUsers.length === 0 && (
+            <p className="text-center text-gray-500">
+              No one has favorited this yet.
+            </p>
+          )}
+
+          {allUsers.map((user: FavoritedUser) => {
+            const isSupporting = currentUserSupportingIds.includes(user.userId);
+            const isCurrentUser = currentUserId === user.userId;
+
+            return (
+              <li
+                key={user.userId}
+                onClick={() => {
+                  onClose();
+                  navigate(`/${user.username}`);
+                }}
+                className="flex items-center gap-3 p-2 rounded hover:bg-gray-100 dark:hover:bg-zinc-800 cursor-pointer"
+              >
+                {user.profileImage ? (
+                  <img
+                    src={user.profileImage}
+                    alt={user.username}
+                    className="w-10 h-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="w-10 h-10 rounded-full bg-gray-400 flex items-center justify-center text-white font-semibold">
+                    {user.name?.charAt(0).toUpperCase() || "U"}
+                  </div>
+                )}
+
+                <div className="flex w-full justify-between items-center">
+                  <div className="flex flex-col">
+                    <div className="flex gap-2 items-center">
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        {user.name || "Unknown User"}
+                      </p>
+                      <p className="text-zinc-400 dark:text-zinc-500 text-xs">
+                        {formatDistanceToNow(new Date(user.favoritedAt), {
+                          addSuffix: true,
+                        })}
+                      </p>
+                    </div>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {user.username || "Unknown User"}
+                    </p>
+                  </div>
+
+                  {/* ✅ Hide Support/UnSupport button if it's the current user */}
+                  {!isCurrentUser && (
+                    <div className="flex items-center gap-3">
+                      <Button
+                        variant={isSupporting ? "unSupport" : "support"}
+                        size="support"
+                        onClick={(e) =>
+                          handleSupportClick(
+                            e,
+                            { id: user.userId, username: user.username || "" },
+                            isSupporting
+                          )
+                        }
+                        disabled={loadingUserId === user.userId}
+                        className="relative flex items-center justify-center"
+                      >
+                        <span
+                          className={`flex items-center gap-1 transition-opacity ${
+                            loadingUserId === user.userId
+                              ? "invisible"
+                              : "visible"
+                          }`}
+                        >
+                          {isSupporting ? (
+                            <>
+                              Supporting <ArrowDownRight size={14} />
+                            </>
+                          ) : (
+                            "Support"
+                          )}
+                        </span>
+
+                        {loadingUserId === user.userId && (
+                          <span className="absolute inset-0 flex items-center justify-center">
+                            <CustomLoader />
+                          </span>
+                        )}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Load More button */}
+        {hasNextPage && (
+          <button
+            className="mt-2 text-blue-500 hover:text-blue-700"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? "Loading more..." : "Load More"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FavoriteUsersModal;

--- a/frontend/src/features/user/components/art/LikeButton.tsx
+++ b/frontend/src/features/user/components/art/LikeButton.tsx
@@ -20,7 +20,6 @@ export const LikeButton = ({
 
   return (
     <div className="flex items-center gap-2 cursor-pointer">
-      {likeCount}{" "}
       <Gem
         size={22}
         onClick={handleClick}

--- a/frontend/src/features/user/components/art/LikeUsersModal.tsx
+++ b/frontend/src/features/user/components/art/LikeUsersModal.tsx
@@ -1,0 +1,240 @@
+import React, { useState } from "react";
+import { X, ArrowDownRight } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { useNavigate } from "react-router-dom";
+import {
+  useGetLikedUsers,
+  type LikedUser,
+} from "../../hooks/art/useGetLikedUsers.ts";
+import UserListSkeleton from "../skeletons/UserListSkeleton.tsx";
+import { Button } from "../../../../components/ui/button";
+import { useSelector } from "react-redux";
+import type { RootState } from "../../../../redux/store";
+import { useGetSupporting } from "../../hooks/profile/useGetSupporting";
+import { useSupportMutation } from "../../hooks/profile/useSupportMutation";
+import { useUnSupportMutation } from "../../hooks/profile/useUnSupportMutation";
+import CustomLoader from "../../../../components/CustomLoader";
+import { formatNumber } from "../../../../libs/formatNumber.ts";
+
+interface LikeUsersModalProps {
+  postId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const LikeUsersModal: React.FC<LikeUsersModalProps> = ({
+  postId,
+  isOpen,
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  const user = useSelector((state: RootState) => state.user.user);
+  const currentUserId = user?.id;
+
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+    isRefetching,
+  } = useGetLikedUsers(postId, isOpen);
+
+  // Supporting query
+  const currentUserSupportingQuery = useGetSupporting(currentUserId || "");
+  const currentUserSupportingIds =
+    currentUserSupportingQuery.data?.pages.flatMap((p) =>
+      p.data.map((u) => u.id)
+    ) || [];
+
+  // Mutations
+  const supportMutation = useSupportMutation();
+  const unSupportMutation = useUnSupportMutation();
+  const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const allUsers = data?.pages.flatMap((page) => page.users) || [];
+
+  const handleSupportClick = (
+    e: React.MouseEvent,
+    targetUser: { id: string; username: string },
+    isSupporting: boolean
+  ) => {
+    e.stopPropagation();
+    if (loadingUserId) return;
+    setLoadingUserId(targetUser.id);
+
+    const payload = { userId: targetUser.id, username: targetUser.username };
+
+    if (isSupporting) {
+      unSupportMutation.mutate(payload, {
+        onSuccess: () => {
+          setLoadingUserId(null);
+          currentUserSupportingQuery.refetch();
+        },
+        onError: () => setLoadingUserId(null),
+      });
+    } else {
+      supportMutation.mutate(payload, {
+        onSuccess: () => {
+          setLoadingUserId(null);
+          currentUserSupportingQuery.refetch();
+        },
+        onError: () => setLoadingUserId(null),
+      });
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* modal */}
+      <div className="relative z-50 bg-white dark:bg-secondary-color border sm:dark:border-zinc-700 sm:rounded-3xl shadow-lg h-full sm:h-[500px] w-full sm:w-[470px] p-4 flex flex-col">
+        {/* close button */}
+        <button
+          className="absolute top-3 right-3 text-zinc-500 hover:text-zinc-700 dark:hover:text-white"
+          onClick={onClose}
+        >
+          <X size={20} />
+        </button>
+
+        {/* title + refetch button */}
+        <div className="flex justify-between items-center mb-4 pb-2 border-b border-zinc-300 dark:border-zinc-700">
+          <h2 className="text-lg text-center font-bold">
+            Likes ( {formatNumber(data?.pages?.[0]?.likeCount ?? 0)} )
+          </h2>
+
+          <button
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="text-sm text-blue-500 pr-10 hover:text-blue-700 disabled:opacity-50"
+          >
+            {isRefetching ? "Refreshing..." : "Refetch"}
+          </button>
+        </div>
+
+        {/* user list */}
+        <ul className="flex-1 overflow-y-auto space-y-3 mt-2">
+          {isLoading &&
+            [...Array(5)].map((_, i) => <UserListSkeleton key={i} />)}
+          {isError && (
+            <p className="text-center text-red-500">Error fetching users.</p>
+          )}
+          {!isLoading && allUsers.length === 0 && (
+            <p className="text-center text-gray-500">
+              No one has liked this yet.
+            </p>
+          )}
+
+          {allUsers.map((user: LikedUser) => {
+            const isSupporting = currentUserSupportingIds.includes(user.userId);
+            const isCurrentUser = currentUserId === user.userId;
+
+            return (
+              <li
+                key={user.userId}
+                onClick={() => {
+                  onClose();
+                  navigate(`/${user.username}`);
+                }}
+                className="flex items-center gap-3 p-2 rounded hover:bg-gray-100 dark:hover:bg-zinc-800 cursor-pointer"
+              >
+                {user.profileImage ? (
+                  <img
+                    src={user.profileImage}
+                    alt={user.username}
+                    className="w-10 h-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="w-10 h-10 rounded-full bg-gray-400 flex items-center justify-center text-white font-semibold">
+                    {user.name?.charAt(0).toUpperCase() || "U"}
+                  </div>
+                )}
+
+                <div className="flex w-full justify-between items-center">
+                  <div className="flex flex-col">
+                    <div className="flex gap-2 items-center">
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        {user.name || "Unknown User"}
+                      </p>
+                      <p className="text-zinc-400 dark:text-zinc-500 text-xs">
+                        {formatDistanceToNow(new Date(user.likedAt), {
+                          addSuffix: true,
+                        })}
+                      </p>
+                    </div>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {user.username || "Unknown User"}
+                    </p>
+                  </div>
+
+                  {/* hide support button for self */}
+                  {!isCurrentUser && (
+                    <div className="flex items-center gap-3">
+                      <Button
+                        variant={isSupporting ? "unSupport" : "support"}
+                        size="support"
+                        onClick={(e) =>
+                          handleSupportClick(
+                            e,
+                            { id: user.userId, username: user.username || "" },
+                            isSupporting
+                          )
+                        }
+                        disabled={loadingUserId === user.userId}
+                        className="relative flex items-center justify-center"
+                      >
+                        <span
+                          className={`flex items-center gap-1 transition-opacity ${
+                            loadingUserId === user.userId
+                              ? "invisible"
+                              : "visible"
+                          }`}
+                        >
+                          {isSupporting ? (
+                            <>
+                              Supporting <ArrowDownRight size={14} />
+                            </>
+                          ) : (
+                            "Support"
+                          )}
+                        </span>
+
+                        {loadingUserId === user.userId && (
+                          <span className="absolute inset-0 flex items-center justify-center">
+                            <CustomLoader />
+                          </span>
+                        )}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Load More button */}
+        {hasNextPage && (
+          <button
+            className="mt-2 text-blue-500 hover:text-blue-700"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? "Loading more..." : "Load More"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LikeUsersModal;

--- a/frontend/src/features/user/components/navbar/UserInfo.tsx
+++ b/frontend/src/features/user/components/navbar/UserInfo.tsx
@@ -55,13 +55,17 @@ const UserInfo = ({ user, isAuthenticated, onBecomeArtist }: UserInfoProps) => {
             )}
           </button>
 
-          <Button
-            variant="main"
-            className="hidden sm:flex"
-            onClick={onBecomeArtist}
-          >
-            Become an Artist
-          </Button>
+          {user.isVerified === false && user.role === "user" ? (
+            <Button
+              variant="main"
+              className="hidden sm:flex"
+              onClick={onBecomeArtist}
+            >
+              Become an Artist
+            </Button>
+          ) : (
+            <></>
+          )}
         </>
       ) : (
         <>

--- a/frontend/src/features/user/components/skeletons/UserListSkeleton.tsx
+++ b/frontend/src/features/user/components/skeletons/UserListSkeleton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const UserListSkeleton: React.FC = () => {
+  return (
+    <li className="flex items-center gap-3 animate-pulse w-full">
+      {/* Profile circle */}
+      <div className="w-10 h-10 rounded-full bg-zinc-300 dark:bg-zinc-800 shrink-0" />
+
+      {/* Text placeholders */}
+      <div className="flex justify-between items-center w-full px-2">
+        <div className="flex flex-col gap-2 w-3/4">
+          <div className="h-3 bg-zinc-300 dark:bg-zinc-800 rounded w-1/3" />
+          <div className="h-3 bg-zinc-300 dark:bg-zinc-800 rounded w-1/4" />
+        </div>
+        <div className="h-3 p-4 bg-zinc-300 dark:bg-zinc-800 rounded w-1/5" />
+      </div>
+    </li>
+  );
+};
+
+export default UserListSkeleton;

--- a/frontend/src/features/user/hooks/art/useFavoritePost.ts
+++ b/frontend/src/features/user/hooks/art/useFavoritePost.ts
@@ -2,36 +2,34 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import apiClient from "../../../../api/axios";
 import type { ArtWithUser } from "./useGetAllArt";
 
-interface LikeVariables {
+interface FavoriteVariables {
   postId: string;
   artname: string;
 }
 
 interface OnMutateContext {
-  prevArt?: { data: { isLiked: boolean; likeCount: number } };
+  prevArt?: { data: { isFavorited: boolean; favoriteCount: number } };
 }
 
-export const useUnlikePost = () => {
+export const useFavoritePost = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ postId }: LikeVariables) => {
-      const { data } = await apiClient.delete("/api/v1/art/unlike", {
-        data: { postId },
-      });
+    mutationFn: async ({ postId }: FavoriteVariables) => {
+      const { data } = await apiClient.post("/api/v1/art/favorite", { postId });
       return data;
     },
 
-    onMutate: ({ postId, artname }: LikeVariables) => {
-      const prevArt = queryClient.getQueryData<{ data: { isLiked: boolean; likeCount: number } }>(["art", artname]);
+    onMutate: ({ postId, artname }: FavoriteVariables) => {
+      const prevArt = queryClient.getQueryData<{ data: { isFavorited: boolean; favoriteCount: number } }>(["art", artname]);
 
       if (prevArt) {
         queryClient.setQueryData(["art", artname], {
           ...prevArt,
           data: {
             ...prevArt.data,
-            isLiked: false,
-            likeCount: prevArt.data.likeCount - 1,
+            isFavorited: true,
+            favoriteCount: (prevArt.data.favoriteCount || 0) + 1,
           },
         });
       }
@@ -46,7 +44,7 @@ export const useUnlikePost = () => {
             ...page,
             data: page.data.map((art: ArtWithUser) =>
               art.art.id === postId
-                ? { ...art, isLiked: false, likeCount: art.likeCount - 1 }
+                ? { ...art, isFavorited: true, favoriteCount: (art.favoriteCount || 0) + 1 }
                 : art
             ),
           })),

--- a/frontend/src/features/user/hooks/art/useGetAllArt.ts
+++ b/frontend/src/features/user/hooks/art/useGetAllArt.ts
@@ -35,7 +35,9 @@ export interface ArtWithUser {
   art: ArtPostResponseDTO;
   user: ArtUser | null;
   isLiked: boolean,
+  isFavorited: boolean,
   likeCount: number,
+  favoriteCount: number;
   commentCount: number
 }
 

--- a/frontend/src/features/user/hooks/art/useGetArtByName.ts
+++ b/frontend/src/features/user/hooks/art/useGetArtByName.ts
@@ -3,7 +3,7 @@ import apiClient from "../../../../api/axios";
 
 // ------------------ Types ------------------
 export interface Price {
-  type: string;       
+  type: string;
   artcoins?: number;
   fiat?: number;
 }
@@ -50,12 +50,14 @@ export interface ArtWithUserResponse {
   message: string;
   data: {
     user: User;
-  art: Art;
-  isLiked: boolean;
-  likeCount: number;
-  commentCount: number;
-  price: Price;
-  }
+    art: Art;
+    isLiked: boolean;
+    isFavorited: boolean;
+    likeCount: number;
+    favoriteCount: number;
+    commentCount: number;
+    price: Price;
+  };
 }
 
 // ------------------ Hook ------------------

--- a/frontend/src/features/user/hooks/art/useGetFavoritedUsers.ts
+++ b/frontend/src/features/user/hooks/art/useGetFavoritedUsers.ts
@@ -1,0 +1,35 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import apiClient from "../../../../api/axios";
+
+export interface FavoritedUser {
+  userId: string;
+  name: string;
+  username?: string;
+  profileImage?: string;
+  favoritedAt: string;
+}
+
+interface FavoritedUsersResponse {
+  users: FavoritedUser[];
+  favoriteCount: number;
+  page: number;
+  limit: number;
+}
+
+export const useGetFavoritedUsers = (postId: string, enabled = true) => {
+  return useInfiniteQuery<FavoritedUsersResponse, Error>({
+    queryKey: ["favoritedUsers", postId],
+    queryFn: async ({ pageParam = 1 }) => {
+      const res = await apiClient.get<FavoritedUsersResponse>(
+        `/api/v1/art/favorites/${postId}?page=${pageParam}&limit=5`
+      );
+      return res.data;
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.users.length < lastPage.limit ? undefined : lastPage.page + 1,
+    initialPageParam: 1,
+    enabled,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/frontend/src/features/user/hooks/art/useGetLikedUsers.ts.ts
+++ b/frontend/src/features/user/hooks/art/useGetLikedUsers.ts.ts
@@ -1,0 +1,35 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import apiClient from "../../../../api/axios";
+
+export interface LikedUser {
+  userId: string;
+  name: string;
+  username?: string;
+  profileImage?: string;
+  likedAt: string;
+}
+
+interface LikedUsersResponse {
+  users: LikedUser[];
+  likeCount: number;
+  page: number;
+  limit: number;
+}
+
+export const useGetLikedUsers = (postId: string, enabled = true) => {
+  return useInfiniteQuery<LikedUsersResponse, Error>({
+    queryKey: ["likedUsers", postId],
+    queryFn: async ({ pageParam = 1 }) => {
+      const res = await apiClient.get<LikedUsersResponse>(
+        `/api/v1/art/likes/${postId}?page=${pageParam}&limit=5`
+      );
+      return res.data;
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.users.length < lastPage.limit ? undefined : lastPage.page + 1,
+    initialPageParam: 1,
+    enabled,
+    refetchOnMount: false, 
+    refetchOnWindowFocus: false,
+  });
+};

--- a/frontend/src/libs/formatNumber.ts
+++ b/frontend/src/libs/formatNumber.ts
@@ -1,0 +1,6 @@
+export const formatNumber = (num: number): string => {
+  if (num >= 1_000_000_000) return (num / 1_000_000_000).toFixed(1) + "B";
+  if (num >= 1_000_000) return (num / 1_000_000).toFixed(1) + "M";
+  if (num >= 1_000) return (num / 1_000).toFixed(1) + "K";
+  return num.toString();
+};

--- a/services/art-service/src/application/interface/usecase/favorite/IAddFavoriteUseCase.ts
+++ b/services/art-service/src/application/interface/usecase/favorite/IAddFavoriteUseCase.ts
@@ -1,0 +1,3 @@
+export interface IAddFavoriteUseCase {
+  execute(postId: string, userId: string): Promise<any>;
+}

--- a/services/art-service/src/application/interface/usecase/favorite/IGetFavoriteCountUseCase.ts
+++ b/services/art-service/src/application/interface/usecase/favorite/IGetFavoriteCountUseCase.ts
@@ -1,0 +1,3 @@
+export interface IGetFavoriteCountUseCase {
+execute(postId: string): Promise<number>;
+}

--- a/services/art-service/src/application/interface/usecase/favorite/IGetFavoritedUsersUseCase.ts
+++ b/services/art-service/src/application/interface/usecase/favorite/IGetFavoritedUsersUseCase.ts
@@ -1,0 +1,3 @@
+export interface IGetFavoritedUsersUseCase {
+execute(postId: string, page: number, limit: number): Promise<any>;
+}

--- a/services/art-service/src/application/interface/usecase/favorite/IRemoveFavoriteUseCase.ts
+++ b/services/art-service/src/application/interface/usecase/favorite/IRemoveFavoriteUseCase.ts
@@ -1,0 +1,3 @@
+export interface IRemoveFavoriteUseCase {
+  execute(postId: string, userId: string): Promise<{ message: string }>;
+}

--- a/services/art-service/src/application/interface/usecase/like/IGetLikedUsersUseCase.ts
+++ b/services/art-service/src/application/interface/usecase/like/IGetLikedUsersUseCase.ts
@@ -1,0 +1,3 @@
+export interface IGetLikedUsersUseCase {
+  execute(postId: string, page: number, limit: number): Promise<any>;
+}

--- a/services/art-service/src/application/usecase/art/GetAllArtWithUserNameUseCase.ts
+++ b/services/art-service/src/application/usecase/art/GetAllArtWithUserNameUseCase.ts
@@ -1,21 +1,19 @@
 import { IArtPostRepository } from "../../../domain/repositories/IArtPostRepository";
 import { ICommentRepository } from "../../../domain/repositories/ICommentRepository";
+import { IFavoriteRepository } from "../../../domain/repositories/IFavoriteRepository";
 import { ILikeRepository } from "../../../domain/repositories/ILikeRepository";
 import { UserService } from "../../../infrastructure/service/UserService";
 import { toArtWithUserResponse } from "../../../utils/mappers/artWithUserMapper";
 
 export class GetAllArtWithUserNameUseCase {
-    constructor(private readonly _artRepo: IArtPostRepository, private readonly _likeRepo: ILikeRepository, private readonly _commentRepo: ICommentRepository) {}
+    constructor(private readonly _artRepo: IArtPostRepository, private readonly _likeRepo: ILikeRepository, private readonly _commentRepo: ICommentRepository, private readonly _favoriteRepo: IFavoriteRepository) {}
    async execute(
-        userId: string,  // Changed from username to userId
+        userId: string,  
         page: number,
         limit: number,
         currentUserId: string
     ): Promise<any[]> {
-
-        console.log("Fetching art for user ID:", userId);
         
-        // // Get user by ID instead of username
         const user = await UserService.getUserById(userId);
         if (!user) throw new Error(`User with ID ${userId} not found`);
 
@@ -25,15 +23,21 @@ export class GetAllArtWithUserNameUseCase {
         return await Promise.all(
             arts.map(async (art: any) => {
                 const likeCount = await this._likeRepo.likeCountByPostId(art._id);
+                const favoriteCount = await this._favoriteRepo.favoriteCountByPostId(art._id);
                 const commentCount = await this._commentRepo.countByPostId(art._id);
                 const isLiked = !!(
                     currentUserId && (await this._likeRepo.findLike(art._id, currentUserId))
+                );
+                const isFavorited = !!(
+                    currentUserId && (await this._favoriteRepo.findFavorite(art._id, currentUserId))
                 );
 
                 return {
                     ...toArtWithUserResponse(art, user),
                     likeCount,
+                    favoriteCount,
                     commentCount,
+                    isFavorited,
                     isLiked,
                 };
             })

--- a/services/art-service/src/application/usecase/art/GetArtByNameUseCase.ts
+++ b/services/art-service/src/application/usecase/art/GetArtByNameUseCase.ts
@@ -6,12 +6,14 @@ import { ART_MESSAGES } from "../../../constants/ArtMessages";
 import { toArtWithUserResponse } from "../../../utils/mappers/artWithUserMapper";
 import { ILikeRepository } from "../../../domain/repositories/ILikeRepository";
 import { ICommentRepository } from "../../../domain/repositories/ICommentRepository";
+import { IFavoriteRepository } from "../../../domain/repositories/IFavoriteRepository";
 
 export class GetArtByNameUseCase implements IGetArtByNameUseCase {
   constructor(
     private readonly _artRepo: IArtPostRepository,
     private readonly _likeRepo: ILikeRepository,
-    private readonly _commentRepo: ICommentRepository
+    private readonly _commentRepo: ICommentRepository,
+    private readonly _favoriteRepo: IFavoriteRepository
   ) {}
 
   async execute(artName: string, currentUserId: string) {
@@ -29,18 +31,24 @@ export class GetArtByNameUseCase implements IGetArtByNameUseCase {
     }
 
     const likeCount = await this._likeRepo.likeCountByPostId(artFull._id);
+      const favoriteCount = await this._favoriteRepo.favoriteCountByPostId(artFull._id);
     const commentCount = await this._commentRepo.countByPostId(artFull._id);
 
     const isLiked = !!(
       currentUserId &&
       (await this._likeRepo.findLike(artFull._id, currentUserId))
     );
+     const isFavorited = !!(
+                    currentUserId && (await this._favoriteRepo.findFavorite(artFull._id, currentUserId))
+                );
 
     return {
       ...toArtWithUserResponse(artFull, userRes.data),
       isLiked,
       likeCount,
+      isFavorited,
       commentCount,
+      favoriteCount,
     };
   }
 }

--- a/services/art-service/src/application/usecase/favorite/AddFavoriteUseCase.ts
+++ b/services/art-service/src/application/usecase/favorite/AddFavoriteUseCase.ts
@@ -1,0 +1,36 @@
+import { IFavoriteRepository } from "../../../domain/repositories/IFavoriteRepository";
+import { Favorite } from "../../../domain/entities/Favorite";
+import { BadRequestError, NotFoundError, ConflictError } from "art-chain-shared";
+import { IAddFavoriteUseCase } from "../../interface/usecase/favorite/IAddFavoriteUseCase";
+import { FAVORITE_MESSAGES } from "../../../constants/FavoriteMessages";
+import { IArtPostRepository } from "../../../domain/repositories/IArtPostRepository";
+import { ART_MESSAGES } from "../../../constants/ArtMessages";
+
+export class AddFavoriteUseCase implements IAddFavoriteUseCase {
+  constructor(
+    private readonly _artRepo: IArtPostRepository,
+    private readonly _favoriteRepository: IFavoriteRepository
+  ) {}
+
+  async execute(postId: string, userId: string) {
+    if (!postId || !userId) {
+      throw new BadRequestError(FAVORITE_MESSAGES.MISSING_USER_ID);
+    }
+
+    const post = await this._artRepo.findById(postId);
+
+    if (!post) {
+      throw new NotFoundError(ART_MESSAGES.ART_NOT_FOUND);
+    }
+
+    const existingFavorite = await this._favoriteRepository.findFavorite(postId, userId);
+    if (existingFavorite) {
+      throw new ConflictError( FAVORITE_MESSAGES.ALREADY_FAVORITED)
+    }
+
+    const favorite = new Favorite(postId, userId);
+    const savedFavorite = await this._favoriteRepository.create(favorite);
+
+    return savedFavorite;
+  }
+}

--- a/services/art-service/src/application/usecase/favorite/GetFavoriteCountUseCase.ts
+++ b/services/art-service/src/application/usecase/favorite/GetFavoriteCountUseCase.ts
@@ -1,0 +1,17 @@
+import { BadRequestError } from "art-chain-shared";
+import { IFavoriteRepository } from "../../../domain/repositories/IFavoriteRepository";
+import { IGetFavoriteCountUseCase } from "../../interface/usecase/favorite/IGetFavoriteCountUseCase";
+import { FAVORITE_MESSAGES } from "../../../constants/FavoriteMessages";
+
+export class GetFavoriteCountUseCase implements IGetFavoriteCountUseCase {
+  constructor(private readonly _favoriteRepository: IFavoriteRepository) {}
+
+  async execute(postId: string) {
+    if (!postId) {
+      throw new BadRequestError("Post ID is required.");
+    }
+
+    const count = await this._favoriteRepository.favoriteCountByPostId(postId);
+    return count;
+  }
+}

--- a/services/art-service/src/application/usecase/favorite/GetFavoritedUsersUseCase.ts
+++ b/services/art-service/src/application/usecase/favorite/GetFavoritedUsersUseCase.ts
@@ -1,0 +1,39 @@
+import { BadRequestError } from "art-chain-shared";
+import { IFavoriteRepository } from "../../../domain/repositories/IFavoriteRepository";
+import { IGetFavoritedUsersUseCase } from "../../interface/usecase/favorite/IGetFavoritedUsersUseCase";
+import { UserService } from "../../../infrastructure/service/UserService";
+
+export class GetFavoritedUsersUseCase implements IGetFavoritedUsersUseCase {
+  constructor(private readonly _favoriteRepository: IFavoriteRepository) {}
+
+  async execute(postId: string, page: number = 1, limit: number = 10) {
+    if (!postId) {
+      throw new BadRequestError("Post ID is required.");
+    }
+
+    const favorites = await this._favoriteRepository.getAllFavoritesByPost(
+      postId,
+      page,
+      limit
+    );
+      const userIds = favorites.map(fav => fav.userId);
+
+    const users = await UserService.getUsersByIds(userIds);
+
+
+    const result = favorites.map(fav => {
+      const user = users.find(u => u.id === fav.userId);
+      return {
+        userId: fav.userId,
+        name: user.name,
+        username: user?.username,
+        profileImage: user?.profileImage,
+        favoritedAt: fav.createdAt,
+      };
+    });
+
+    const favoriteCount = await this._favoriteRepository.favoriteCountByPostId(postId)
+
+    return { users: result, favoriteCount };
+  }
+}

--- a/services/art-service/src/application/usecase/favorite/RemoveFavoriteUseCase.ts
+++ b/services/art-service/src/application/usecase/favorite/RemoveFavoriteUseCase.ts
@@ -1,0 +1,22 @@
+import { IFavoriteRepository } from "../../../domain/repositories/IFavoriteRepository";
+import { IRemoveFavoriteUseCase } from "../../interface/usecase/favorite/IRemoveFavoriteUseCase";
+import { FAVORITE_MESSAGES } from "../../../constants/FavoriteMessages";
+import { BadRequestError } from "art-chain-shared";
+
+export class RemoveFavoriteUseCase implements IRemoveFavoriteUseCase {
+  constructor(private readonly _favoriteRepository: IFavoriteRepository) {}
+
+  async execute(postId: string, userId: string) {
+    if (!postId || !userId) {
+      throw new BadRequestError(FAVORITE_MESSAGES.MISSING_USER_ID);
+    }
+
+    const existingFavorite = await this._favoriteRepository.findFavorite(postId, userId);
+    if (!existingFavorite) {
+      throw new BadRequestError(FAVORITE_MESSAGES.CANNOT_REMOVE_FAVORITE);
+    }
+
+    await this._favoriteRepository.deleteFavorite(postId, userId);
+    return { message: FAVORITE_MESSAGES.REMOVE_SUCCESS };
+  }
+}

--- a/services/art-service/src/application/usecase/like/GetLikedUsersUseCase.ts
+++ b/services/art-service/src/application/usecase/like/GetLikedUsersUseCase.ts
@@ -1,0 +1,36 @@
+import { BadRequestError } from "art-chain-shared";
+import { ILikeRepository } from "../../../domain/repositories/ILikeRepository";
+import { IGetLikedUsersUseCase } from "../../interface/usecase/like/IGetLikedUsersUseCase";
+import { UserService } from "../../../infrastructure/service/UserService";
+
+export class GetLikedUsersUseCase implements IGetLikedUsersUseCase {
+  constructor(private readonly _likeRepo: ILikeRepository) {}
+
+  async execute(postId: string, page: number = 1, limit: number = 10) {
+    if (!postId) {
+      throw new BadRequestError("Post ID is required.");
+    }
+
+    const likes = await this._likeRepo.getAllLikesByPost(postId, page, limit);
+
+      const userIds = likes.map(like => like.userId);
+
+    const users = await UserService.getUsersByIds(userIds);
+
+
+    const result = likes.map(like => {
+      const user = users.find(u => u.id === like.userId);
+      return {
+        userId: like.userId,
+        name: user.name,
+        username: user?.username,
+        profileImage: user?.profileImage,
+        likedAt: like.createdAt,
+      };
+    });
+
+    const likeCount = await this._likeRepo.likeCountByPostId(postId)
+
+    return { users: result, likeCount };
+  }
+}

--- a/services/art-service/src/constants/FavoriteMessages.ts
+++ b/services/art-service/src/constants/FavoriteMessages.ts
@@ -1,0 +1,9 @@
+export enum FAVORITE_MESSAGES {
+  ADD_SUCCESS = "Post added to favorites successfully",
+  REMOVE_SUCCESS = "Post removed from favorites successfully",
+  FETCH_SUCCESS = "Favorites fetched successfully",
+  ALREADY_FAVORITED = "Already favorited this post",
+  MISSING_USER_ID = "Missing x-user-id header",
+  CANNOT_REMOVE_FAVORITE = "Cannot remove a post that is not in favorites",
+    FAVORITED_USERS_FETCHED_SUCCESS = "Favorited users fetched successfully"
+}

--- a/services/art-service/src/constants/LikeMessages.ts
+++ b/services/art-service/src/constants/LikeMessages.ts
@@ -5,4 +5,5 @@ export enum LIKE_MESSAGES {
   ALREADY_LIKED = "Already liked this post",
   MISSING_USER_ID = "Missing x-user-id header",
   CANNOT_UNLIKE_THE_POST = "Cannot unlike a post that is not liked.",
+  LIKED_USERS_FETCHED_SUCCESS = "Liked users fetched successfully"
 }

--- a/services/art-service/src/infrastructure/container/artContainer.ts
+++ b/services/art-service/src/infrastructure/container/artContainer.ts
@@ -12,21 +12,23 @@ import { ArtToElasticSearchUseCase } from "../../application/usecase/art/ArtToEl
 import { LikeRepositoryImpl } from "../repositories/LikeRepositoryImpl";
 import { CommentRepositoryImpl } from "../repositories/CommentRepositoryImpl";
 import { GetAllArtWithUserNameUseCase } from "../../application/usecase/art/GetAllArtWithUserNameUseCase";
+import { FavoriteRepositoryImpl } from "../repositories/FavoriteRepositoryImpl";
 
 // Repositories
 const likeRepo = new LikeRepositoryImpl()
 const artRepo = new ArtPostRepositoryImpl();
 const commentRepo = new CommentRepositoryImpl();
 const categoryRepo = new CategoryRepositoryImpl();
+const favoriteRepo = new FavoriteRepositoryImpl()
 
 // Use Cases
 const getArtByIdUseCase = new GetArtByIdUseCase(artRepo);
 const countArtWorkUseCase = new CountArtWorkUseCase(artRepo);
 const artToElasticSearchUseCase = new ArtToElasticSearchUseCase();
 const createArtUseCase = new CreateArtPostUseCase(artRepo, categoryRepo);
-const getArtByNameUseCase = new GetArtByNameUseCase(artRepo, likeRepo, commentRepo);
-const getAllArtUseCase = new GetAllArtUseCase(artRepo, likeRepo, commentRepo, categoryRepo);
-const getAllArtWithUserNameUseCase = new GetAllArtWithUserNameUseCase(artRepo, likeRepo, commentRepo)
+const getArtByNameUseCase = new GetArtByNameUseCase(artRepo, likeRepo, commentRepo, favoriteRepo);
+const getAllArtUseCase = new GetAllArtUseCase(artRepo, likeRepo, commentRepo, categoryRepo, favoriteRepo);
+const getAllArtWithUserNameUseCase = new GetAllArtWithUserNameUseCase(artRepo, likeRepo, commentRepo, favoriteRepo)
 
 // Controller
 export const artController = new ArtController(

--- a/services/art-service/src/infrastructure/container/favoriteContainer.ts
+++ b/services/art-service/src/infrastructure/container/favoriteContainer.ts
@@ -1,0 +1,25 @@
+import { AddFavoriteUseCase } from "../../application/usecase/favorite/AddFavoriteUseCase";
+import { RemoveFavoriteUseCase } from "../../application/usecase/favorite/RemoveFavoriteUseCase";
+import { GetFavoriteCountUseCase } from "../../application/usecase/favorite/GetFavoriteCountUseCase";
+import { GetFavoritedUsersUseCase } from "../../application/usecase/favorite/GetFavoritedUsersUseCase";
+import { FavoriteController } from "../../presentation/controllers/FavoriteController";
+import { FavoriteRepositoryImpl } from "../repositories/FavoriteRepositoryImpl";
+import { ArtPostRepositoryImpl } from "../repositories/ArtPostRepositoryImpl";
+
+// Repositories
+const artRepo = new ArtPostRepositoryImpl(); 
+const favoriteRepo = new FavoriteRepositoryImpl();
+
+// Use cases
+const addFavoriteUseCase = new AddFavoriteUseCase(artRepo, favoriteRepo);
+const removeFavoriteUseCase = new RemoveFavoriteUseCase(favoriteRepo);
+const getFavoriteCountUseCase = new GetFavoriteCountUseCase(favoriteRepo);
+const getFavoritedUsersUseCase = new GetFavoritedUsersUseCase(favoriteRepo);
+
+// Controller
+export const favoriteController = new FavoriteController(
+  addFavoriteUseCase,
+  removeFavoriteUseCase,
+  getFavoriteCountUseCase,
+  getFavoritedUsersUseCase
+);

--- a/services/art-service/src/infrastructure/container/likeContainer.ts
+++ b/services/art-service/src/infrastructure/container/likeContainer.ts
@@ -1,3 +1,4 @@
+import { GetLikedUsersUseCase } from './../../application/usecase/like/GetLikedUsersUseCase';
 import { UserService } from './../service/UserService';
 import { GetLikeCountUseCase } from "../../application/usecase/like/GetLikeCountUseCase";
 import { LikePostUseCase } from "../../application/usecase/like/LikePostUseCase";
@@ -14,10 +15,12 @@ const artRepo = new ArtPostRepositoryImpl();
 const likePostUseCase = new LikePostUseCase(artRepo, likeRepo);
 const unlikePostUseCase = new UnlikePostUseCase(likeRepo);
 const getLikeCountUseCase = new GetLikeCountUseCase(likeRepo);
+const getLikedUsersUseCase = new GetLikedUsersUseCase(likeRepo)
 
 // Controller
 export const likeController = new LikeController(
   likePostUseCase,
   unlikePostUseCase,
-  getLikeCountUseCase
+  getLikeCountUseCase,
+  getLikedUsersUseCase
 );

--- a/services/art-service/src/presentation/interface/IFavoriteController.ts
+++ b/services/art-service/src/presentation/interface/IFavoriteController.ts
@@ -1,0 +1,8 @@
+import { Request, Response, NextFunction } from "express";
+
+export interface IFavoriteController {
+  addFavorite(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
+  removeFavorite(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
+  getFavoriteCount(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
+  getFavoritedUsers(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
+}

--- a/services/art-service/src/presentation/interface/ILikeController.ts
+++ b/services/art-service/src/presentation/interface/ILikeController.ts
@@ -4,4 +4,5 @@ export interface ILikeController {
   likePost(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
   unlikePost(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
   getLikeCount(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
+  getLikedUsers(req: Request, res: Response, next: NextFunction): Promise<Response | void>;
 }

--- a/services/art-service/src/presentation/routes/art.routes.ts
+++ b/services/art-service/src/presentation/routes/art.routes.ts
@@ -3,32 +3,39 @@ import { artController } from "../../infrastructure/container/artContainer";
 import { commentController } from "../../infrastructure/container/commentContainer";
 import { categoryController } from "../../infrastructure/container/categoryContainer";
 import { likeController } from "../../infrastructure/container/likeContainer";
+import { favoriteController } from "../../infrastructure/container/favoriteContainer";
 
 const router = express.Router();
 
 // Category
-router.get("/category", categoryController.getCategory)
-router.post("/category", categoryController.createCategory)
-router.patch("/category/:id", categoryController.editCategory)
+router.get("/category", categoryController.getCategory);
+router.post("/category", categoryController.createCategory);
+router.patch("/category/:id", categoryController.editCategory);
 
 // Art
 router.get("/", artController.getAllArt);
 router.post("/", artController.createArt);
+router.get("/user", artController.getArtWithUser);
+router.get("/count/:userId", artController.countArtwork);
 router.get("/by-name/:artname", artController.getArtByArtName);
-router.get("/count/:userId", artController.countArtwork)
-router.get("/user", artController.getArtWithUser)
-
-
 
 // Comment
+router.patch("/comment", commentController.editComment);
 router.post("/comment", commentController.createComment);
+router.delete("/comment", commentController.deleteComment);
 router.get("/comments/:postId", commentController.getComments);
-router.patch("/comment", commentController.editComment)
-router.delete("/comment", commentController.deleteComment)
 
-// Like
-router.post("/like", likeController.likePost)
-router.delete("/disLike", likeController.unlikePost)
-router.get("/likes", likeController.getLikeCount)
+// Likes
+router.post("/like", likeController.likePost);
+router.delete("/unlike", likeController.unlikePost);
+router.get("/likes/:postId", likeController.getLikedUsers);
+router.get("/likes-count/:postId", likeController.getLikeCount);
+
+// Favorites
+router.post("/favorite", favoriteController.addFavorite);
+router.delete("/unfavorite", favoriteController.removeFavorite);
+router.get("/favorites/:postId", favoriteController.getFavoritedUsers);
+router.get("/favorites-count/:postId", favoriteController.getFavoriteCount);
+
 
 export default router;


### PR DESCRIPTION
This merge introduces full favorite and like functionalities for art posts, including user engagement features and UI enhancements. Key updates include:

Frontend:
Implement favorite/unfavorite functionality using hooks and UI components.
Add modals to display lists of users who liked or favorited an art piece.
Create skeleton components for loading states.
Add formatNumber utility for displaying counts in a user-friendly format (e.g., 1K, 1M).
Improve like button UI with conditional rendering for support/follow buttons.

Backend:
Add new endpoints for like/unlike and favorite/unfavorite operations.
Implement CRUD operations for favorites with proper controllers and routes.
Update art use cases (GetArtByNameUseCase, GetAllArtUseCase, GetAllArtWithUserNameUseCase) to include favorite counts and user-specific favorite status.
Include dependency injection for favorite-related components and consistent response messages.

Implement pagination support for fetching users who liked or favorited an art post.